### PR TITLE
refactor: 命名空间列表选择与editable关联

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,11 @@
 
 workdir=$(dirname $(realpath $0))
 version=$(cat version 2>/dev/null)
+
+if [ $# == 1 ]; then
+  version=$1
+fi
+
 bin_name="polaris-console"
 if [ "${GOOS}" == "" ]; then
   GOOS=$(go env GOOS)

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/polarismesh/polaris-console/bootstrap"
-	"github.com/polarismesh/polaris-console/handlers"
 	"github.com/polarismesh/polaris-console/router"
 )
 
@@ -40,9 +39,6 @@ func main() {
 
 	// 设置模式
 	bootstrap.SetMode(config)
-
-	// 请求部门数据
-	handlers.SetDepartment()
 
 	// 路由请求
 	router.Router(config)

--- a/web/src/polaris/auth/login/Page.tsx
+++ b/web/src/polaris/auth/login/Page.tsx
@@ -90,7 +90,7 @@ export default purify(function(props: DuckCmpProps<Duck>) {
                       <Col>
                         <Text theme={'weak'} parent={'div'} style={{ width: '100%' }} align={'center'}>
                           初始用户名和密码为<Copy text={'polaris'}>polaris</Copy>/
-                          <Copy text={'polarismesh@2021'}>polarismesh@2021</Copy>
+                          <Copy text={'polaris'}>polaris</Copy>
                         </Text>
                       </Col>
                     </Row>

--- a/web/src/polaris/service/operation/CreateDuck.ts
+++ b/web/src/polaris/service/operation/CreateDuck.ts
@@ -4,7 +4,7 @@ import { put, select } from 'redux-saga/effects'
 import { createService, modifyServices, describeNamespaces } from '../model'
 import { resolvePromise } from 'saga-duck/build/helper'
 import { NamespaceItem } from '../PageDuck'
-import { isReadOnly } from '../utils'
+import { isReadOnly, isReadOnlyNamespace } from '../utils'
 import { getAllList } from '@src/polaris/common/util/apiRequest'
 import { describeGovernanceStrategies, AuthStrategy } from '@src/polaris/auth/model'
 import { UserSelectDuck } from '@src/polaris/auth/userGroup/operation/CreateDuck'
@@ -163,7 +163,7 @@ export default class CreateDuck extends FormDialog {
       payload: {
         ...options,
         namespaceList: namespaceList.map(item => {
-          const disabled = isReadOnly(item.name)
+          const disabled = isReadOnlyNamespace(item)
           return {
             ...item,
             value: item.name,

--- a/web/src/polaris/service/utils.tsx
+++ b/web/src/polaris/service/utils.tsx
@@ -1,4 +1,4 @@
-import { READ_ONLY_NAMESPACE } from './types'
+import { Namespace, READ_ONLY_NAMESPACE } from './types'
 import { Modal, Table } from 'tea-component'
 import React from 'react'
 import { scrollable } from 'tea-component/lib/table/addons'
@@ -6,6 +6,10 @@ import LabelTable from '../common/components/LabelTable'
 
 export const isReadOnly = (namespace: string) => {
   return READ_ONLY_NAMESPACE.indexOf(namespace) !== -1
+}
+
+export const isReadOnlyNamespace = (namespace: Namespace) => {
+  return !namespace.editable
 }
 
 export const showAllLabels = (labels) => {


### PR DESCRIPTION
- 默认账户信息修改为 polaris:polaris
- 鉴权开启，创建服务时，对于没有写权限的命名空间，下拉列表不予选择
- 修复构建脚本丢失 version 信息