### PR TITLE
feat: 前端小功能优化

### DIFF
--- a/web/src/polaris/configuration/fileGroup/detail/file/Page.tsx
+++ b/web/src/polaris/configuration/fileGroup/detail/file/Page.tsx
@@ -94,7 +94,7 @@ export default function Page(props: DuckCmpProps<Duck>) {
       <Card>
         <Card.Body>
           <Row showSplitLine gap={40}>
-            <div style={{ width: '450px', height: 600, overflowY: 'hidden', margin: '15px 20px' }}>
+            <div style={{ width: '450px', height: 1000, overflowY: 'hidden', margin: '15px 20px' }}>
               <SearchBox
                 value={searchKeyword}
                 onChange={handlers.setSearchKeyword}
@@ -126,14 +126,14 @@ export default function Page(props: DuckCmpProps<Duck>) {
                   handlers.setExpandedIds(expandedIds)
                 }}
                 fullExpandable
-                height={600}
+                height={900}
                 style={{ width: '500px' }}
-                // onSelect={v => {
-                //   handlers.select(v)
-                // }}
-                // selectable
-                // selectedIds={selection}
-                // selectValueMode={'onlyLeaf'}
+              // onSelect={v => {
+              //   handlers.select(v)
+              // }}
+              // selectable
+              // selectedIds={selection}
+              // selectValueMode={'onlyLeaf'}
               >
                 {renderTree(props, fileTree, '', '')}
               </Tree>
@@ -281,7 +281,7 @@ export default function Page(props: DuckCmpProps<Duck>) {
                             language={currentNode?.format}
                             value={editing ? editContent : currentNode?.content}
                             options={{ readOnly: !editing }}
-                            height={400}
+                            height={700}
                             width={'100%'}
                             onChange={v => {
                               handlers.setEditContent(v)

--- a/web/src/polaris/configuration/fileGroup/detail/file/operation/Create.tsx
+++ b/web/src/polaris/configuration/fileGroup/detail/file/operation/Create.tsx
@@ -92,6 +92,15 @@ const CreateForm = purify(function CreateForm(props: DuckCmpProps<Duck>) {
             field={name}
             disabled={options.isModify}
             maxLength={128}
+            onChange={(val, ctx) => {
+              const suffix = val.substring(val.lastIndexOf(".") + 1);
+              console.log(suffix)
+              FileFormatOptions.forEach((item) => {
+                if (suffix == item.text) {
+                  format.setValue(suffix)
+                }
+              })
+            }}
             placeholder={'允许数字、英文字母、.、-、_，限制128个字符'}
             size={'l'}
           />


### PR DESCRIPTION
- 创建配置文件时，文件的格式自动从文件名中识别，如果识别不到，在由用户手动选择
  - 建议后续前端这里应该不需要用户填写 format 字段，前端自动解析  xxx.{format}
- 调整创建配置文件页面 Card body 的高度，尽可能充满整个浏览器