### PR TITLE
feat: change client token to jwt token

### DIFF
--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -91,7 +91,7 @@ type WebServer struct {
 // JWT jwtToken 相关的配置
 type JWT struct {
 	// 参与jwt运算的key
-	Key string `yaml:"key"`
+	SecretKey string `yaml:"secretKey"`
 	// 过期时间, 单位为秒
 	Expired int `yaml:"expired"`
 }
@@ -114,7 +114,7 @@ func LoadConfig(filePath string) (*Config, error) {
 
 	config := &Config{}
 	config.WebServer.JWT.Expired = 1800 // 默认30分钟
-	config.WebServer.JWT.Key = "polarismesh@2021"
+	config.WebServer.JWT.SecretKey = "polarismesh@2021"
 	err = yaml.NewDecoder(file).Decode(config)
 	if err != nil {
 		fmt.Printf("[ERROR] %v\n", err)

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -85,8 +85,15 @@ type WebServer struct {
 	MonitorURL string `yaml:"monitorURL"`
 	ConfigURL  string `yaml:"configURL"`
 	WebPath    string `yaml:"webPath"`
-	JwtKey     string `yaml:"jwtKey"`
-	JwtExpired int    `yaml:"jwtExpired"`
+	JWT        JWT    `yaml:"jwt"`
+}
+
+// JWT jwtToken 相关的配置
+type JWT struct {
+	// 参与jwt运算的key
+	Key string `yaml:"key"`
+	// 过期时间, 单位为秒
+	Expired int `yaml:"expired"`
 }
 
 // LoadConfig 加载配置文件
@@ -106,8 +113,8 @@ func LoadConfig(filePath string) (*Config, error) {
 	}
 
 	config := &Config{}
-	config.WebServer.JwtExpired = 1800 // 默认30分钟
-	config.WebServer.JwtKey = "polarismesh@2021"
+	config.WebServer.JWT.Expired = 1800 // 默认30分钟
+	config.WebServer.JWT.Key = "polarismesh@2021"
 	err = yaml.NewDecoder(file).Decode(config)
 	if err != nil {
 		fmt.Printf("[ERROR] %v\n", err)

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -85,6 +85,8 @@ type WebServer struct {
 	MonitorURL string `yaml:"monitorURL"`
 	ConfigURL  string `yaml:"configURL"`
 	WebPath    string `yaml:"webPath"`
+	JwtKey     string `yaml:"jwtKey"`
+	JwtExpired int    `yaml:"jwtExpired"`
 }
 
 // LoadConfig 加载配置文件
@@ -104,6 +106,8 @@ func LoadConfig(filePath string) (*Config, error) {
 	}
 
 	config := &Config{}
+	config.WebServer.JwtExpired = 1800 // 默认30分钟
+	config.WebServer.JwtKey = "polarismesh@2021"
 	err = yaml.NewDecoder(file).Decode(config)
 	if err != nil {
 		fmt.Printf("[ERROR] %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/gin-gonic/gin v1.4.0
+	github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	go.uber.org/zap v1.13.0
 	google.golang.org/grpc v1.25.1

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NB
 github.com/gin-gonic/gin v1.4.0 h1:3tMoCCfM7ppqsR0ptz/wi1impNpT7/9wQtMZ8lr1mCQ=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
+github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
+github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -263,7 +263,7 @@ func parseJWTThenSetToken(c *gin.Context, conf *bootstrap.Config) (string, strin
 		return "", "", nil
 	}
 	token, err := jwt.ParseWithClaims(jwtCookie.Value, &jwtClaims{}, func(token *jwt.Token) (interface{}, error) {
-		return []byte(conf.WebServer.JWT.Key), nil
+		return []byte(conf.WebServer.JWT.SecretKey), nil
 	})
 	if _, ok := err.(*jwt.ValidationError); ok {
 		return "", "", err
@@ -292,7 +292,7 @@ func refreshJWT(c *gin.Context, userID, token string, conf *bootstrap.Config) er
 			IssuedAt:  jwt.NewNumericDate(nowTime),
 		},
 	}
-	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(conf.WebServer.JWT.Key))
+	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(conf.WebServer.JWT.SecretKey))
 	if err != nil {
 		return err
 	}

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -263,7 +263,7 @@ func parseJWTThenSetToken(c *gin.Context, conf *bootstrap.Config) (string, strin
 		return "", "", nil
 	}
 	token, err := jwt.ParseWithClaims(jwtCookie.Value, &jwtClaims{}, func(token *jwt.Token) (interface{}, error) {
-		return []byte(conf.WebServer.JwtKey), nil
+		return []byte(conf.WebServer.JWT.Key), nil
 	})
 	if _, ok := err.(*jwt.ValidationError); ok {
 		return "", "", err
@@ -287,15 +287,15 @@ func refreshJWT(c *gin.Context, userID, token string, conf *bootstrap.Config) er
 		UserID: userID,
 		Token:  token,
 		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(nowTime.Add(time.Duration(conf.WebServer.JwtExpired) * time.Second)),
+			ExpiresAt: jwt.NewNumericDate(nowTime.Add(time.Duration(conf.WebServer.JWT.Expired) * time.Second)),
 			NotBefore: jwt.NewNumericDate(nowTime),
 			IssuedAt:  jwt.NewNumericDate(nowTime),
 		},
 	}
-	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(conf.WebServer.JwtKey))
+	jwtToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(conf.WebServer.JWT.Key))
 	if err != nil {
 		return err
 	}
-	c.SetCookie("jwt", jwtToken, conf.WebServer.JwtExpired, "/", "", false, false)
+	c.SetCookie("jwt", jwtToken, conf.WebServer.JWT.Expired, "/", "", false, false)
 	return nil
 }

--- a/handlers/proxy_test.go
+++ b/handlers/proxy_test.go
@@ -1,0 +1,57 @@
+/**
+ * Tencent is pleased to support the open source community by making Polaris available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/polarismesh/polaris-console/bootstrap"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRefreshJWTAndParse(t *testing.T) {
+	conf := &bootstrap.Config{}
+	conf.WebServer.JwtExpired = 2
+	conf.WebServer.JwtKey = "polarismesh@2021"
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	userID, token := "user1", "token1"
+	err := refreshJWT(c, userID, token, conf)
+	assert.NoError(t, err, "refresh jwt should not fail")
+	time.Sleep(time.Second)
+
+	c.Request = &http.Request{
+		Header: map[string][]string{
+			"Cookie": {c.Writer.Header().Get("Set-Cookie")},
+		},
+	}
+	targetUserID, targetToken, err := parseJWTThenSetToken(c, conf)
+	assert.NoError(t, err, "parse jwt should not fail")
+	if targetUserID != userID {
+		t.Errorf("user id should be same to target")
+	}
+	if targetToken != token {
+		t.Errorf("token should be same to target")
+	}
+	time.Sleep(2 * time.Second)
+	_, _, err = parseJWTThenSetToken(c, conf)
+	assert.Error(t, err, "token should be expire")
+}

--- a/handlers/proxy_test.go
+++ b/handlers/proxy_test.go
@@ -31,7 +31,7 @@ import (
 func TestRefreshJWTAndParse(t *testing.T) {
 	conf := &bootstrap.Config{}
 	conf.WebServer.JWT.Expired = 2
-	conf.WebServer.JWT.Key = "polarismesh@2021"
+	conf.WebServer.JWT.SecretKey = "polarismesh@2021"
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	userID, token := "user1", "token1"
 	err := refreshJWT(c, userID, token, conf)

--- a/handlers/proxy_test.go
+++ b/handlers/proxy_test.go
@@ -30,8 +30,8 @@ import (
 
 func TestRefreshJWTAndParse(t *testing.T) {
 	conf := &bootstrap.Config{}
-	conf.WebServer.JwtExpired = 2
-	conf.WebServer.JwtKey = "polarismesh@2021"
+	conf.WebServer.JWT.Expired = 2
+	conf.WebServer.JWT.Key = "polarismesh@2021"
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	userID, token := "user1", "token1"
 	err := refreshJWT(c, userID, token, conf)

--- a/polaris-console.yaml
+++ b/polaris-console.yaml
@@ -9,7 +9,7 @@ webServer:
   listenIP: "0.0.0.0"
   listenPort: 8080
   jwt:
-    key: "polarismesh@2021"
+    secretKey: "polarismesh@2021"
     expired: 1800
   namingURL: "/naming/v1"
   authURL: "/core/v1"

--- a/polaris-console.yaml
+++ b/polaris-console.yaml
@@ -8,6 +8,8 @@ webServer:
   mode: "release"
   listenIP: "0.0.0.0"
   listenPort: 8080
+  jwtKey: "polarismesh@2021"
+  jwtExpired: 1800
   namingURL: "/naming/v1"
   authURL: "/core/v1"
   requestURL: "/naming/v1"

--- a/polaris-console.yaml
+++ b/polaris-console.yaml
@@ -8,8 +8,9 @@ webServer:
   mode: "release"
   listenIP: "0.0.0.0"
   listenPort: 8080
-  jwtKey: "polarismesh@2021"
-  jwtExpired: 1800
+  jwt:
+    key: "polarismesh@2021"
+    expired: 1800
   namingURL: "/naming/v1"
   authURL: "/core/v1"
   requestURL: "/naming/v1"


### PR DESCRIPTION
解决issue: https://github.com/polarismesh/polaris/issues/517

1. 登陆反向代理处, 新增含有过期时间的jwt代替clientToken, jwt过期会自动跳转回登陆页面 ,并设置cookie 和隐藏接口响应体的的ClientToken
2. Server反向代理处, 尝试验证jwt和解除jwt, 从中得出UserID 和 ClientToken, 走原有的鉴权ClientToken逻辑, 比如验证token是否被重置等
3. jwt会在有server接口访问, 并验证通过后自动续期