### PR TITLE
fix: 新建路由规则返回的tab不正确 release-v1.9.0

### DIFF
--- a/web/src/polaris/administration/dynamicRoute/customRoute/operations/Create.tsx
+++ b/web/src/polaris/administration/dynamicRoute/customRoute/operations/Create.tsx
@@ -726,7 +726,7 @@ export default purify(function CustomRoutePage(props: DuckCmpProps<CreateDuck>) 
               onClick={() => {
                 if (composedId?.namespace) {
                   router.navigate(
-                    `/service-detail?name=${composedId?.service}&namespace=${composedId?.namespace}&tab=${TAB.AccessLimit}`,
+                    `/service-detail?name=${composedId?.service}&namespace=${composedId?.namespace}&tab=${TAB.Route}`,
                   )
                 } else {
                   router.navigate(`/custom-route`)


### PR DESCRIPTION
fix: 新建路由规则返回的tab不正确