### PR TITLE
支持 `.properties` & `xml` 语法高亮

### DIFF
--- a/web/build/webpack.base.conf.js
+++ b/web/build/webpack.base.conf.js
@@ -91,7 +91,7 @@ module.exports = {
     }),
     new MonacoWebpackPlugin({
       // 所需语言支持
-      languages: ["json", "yaml", "ini"],
+      languages: ["json", "yaml", "ini", "xml"],
       // targetName 业务名
       filename: `static/js/[name].js`,
     }),

--- a/web/build/webpack.base.conf.js
+++ b/web/build/webpack.base.conf.js
@@ -91,7 +91,7 @@ module.exports = {
     }),
     new MonacoWebpackPlugin({
       // 所需语言支持
-      languages: ["json", "yaml"],
+      languages: ["json", "yaml", "ini"],
       // targetName 业务名
       filename: `static/js/[name].js`,
     }),

--- a/web/src/polaris/configuration/fileGroup/detail/file/Page.tsx
+++ b/web/src/polaris/configuration/fileGroup/detail/file/Page.tsx
@@ -29,6 +29,7 @@ import { autotip, radioable, scrollable } from 'tea-component/lib/table/addons'
 import FileDiff from './FileDiff'
 import MonacoEditor from '@src/polaris/common/components/MocacoEditor'
 import { Link } from 'react-router-dom'
+import { FileFormat } from './operation/Create'
 
 export const NoSearchResultKey = '__NO_SEARCH_RESULT__'
 const getHandlers = memorize(({ creators }: Duck, dispatch) => ({
@@ -74,6 +75,18 @@ insertCSS(
   }
 `,
 )
+
+function toHighlightLanguage(format?: string) {
+  if (!format) {
+    return FileFormat.TEXT
+  }
+  // monaco 对 .properties 格式需要将语言转为 ini
+  // @see https://github.com/microsoft/monaco-editor/blob/main/src/basic-languages/ini/ini.contribution.ts
+  if (format === FileFormat.PROPERTIES) {
+    return 'ini'
+  }
+  return format
+}
 
 export default function Page(props: DuckCmpProps<Duck>) {
   const { duck, store, dispatch } = props
@@ -287,7 +300,7 @@ export default function Page(props: DuckCmpProps<Duck>) {
                                 <FileDiff
                                   original={currentHistoryDuck.selector(store).selected?.content}
                                   now={currentNode?.content}
-                                  format={currentNode?.format}
+                                  format={toHighlightLanguage(currentNode?.format)}
                                 />
                               </section>
                             ) : (
@@ -298,7 +311,7 @@ export default function Page(props: DuckCmpProps<Duck>) {
                       ) : (
                         <section style={{ border: '1px solid #cfd5de', width: '100%' }}>
                           <MonacoEditor
-                            language={currentNode?.format}
+                            language={toHighlightLanguage(currentNode?.format)}
                             value={editing ? editContent : currentNode?.content}
                             options={{ readOnly: !editing }}
                             height={700}

--- a/web/src/polaris/configuration/fileGroup/detail/file/Page.tsx
+++ b/web/src/polaris/configuration/fileGroup/detail/file/Page.tsx
@@ -85,6 +85,9 @@ function toHighlightLanguage(format?: string) {
   if (format === FileFormat.PROPERTIES) {
     return 'ini'
   }
+  if (format === 'yml') {
+    return FileFormat.YAML
+  }
   return format
 }
 


### PR DESCRIPTION
see issue https://github.com/polarismesh/polaris-console/issues/118

monaco ini language config: https://github.com/microsoft/monaco-editor/blob/22698f2c1b65020c7fd9375739d3072c704dd5a4/src/basic-languages/ini/ini.contribution.ts#L12-L15

<img width="983" alt="image" src="https://user-images.githubusercontent.com/22773923/194709987-ea587d46-1f85-4012-a435-8de75301f1af.png">
