### PR TITLE
fix: disable add/edit/publish buttons in filegroup detail pages when no permission

### DIFF
--- a/web/src/polaris/configuration/fileGroup/detail/file/Page.tsx
+++ b/web/src/polaris/configuration/fileGroup/detail/file/Page.tsx
@@ -117,7 +117,7 @@ export default function Page(props: DuckCmpProps<Duck>) {
   const searchKeyword = selectors.searchKeyword(store)
   const editing = selectors.editing(store)
   const fileTree = selectors.fileTree(store)
-  const { showHistoryMap, editContent } = selector(store)
+  const { showHistoryMap, editContent, data } = selector(store)
   const currentHistoryDuck = ducks.configFileDynamicDuck.getDuck(currentNode?.name)
 
   function RefreshConfigButton(): JSX.Element {
@@ -157,7 +157,7 @@ export default function Page(props: DuckCmpProps<Duck>) {
         <Justify
           left={
             <>
-              <Button type={'primary'} onClick={() => handlers.add()}>
+              <Button type={'primary'} disabled={!data.editable} onClick={() => handlers.add()}>
                 新增
               </Button>
               <RefreshConfigButton />
@@ -295,7 +295,11 @@ export default function Page(props: DuckCmpProps<Duck>) {
                         style={{ marginBottom: '20px' }}
                         left={
                           <>
-                            <Button type={'primary'} disabled={editing} onClick={() => handlers.releaseCurrentFile()}>
+                            <Button
+                              type={'primary'}
+                              disabled={editing || !data.editable}
+                              onClick={() => handlers.releaseCurrentFile()}
+                            >
                               发布
                             </Button>
 
@@ -309,7 +313,11 @@ export default function Page(props: DuckCmpProps<Duck>) {
                                 </Button>
                               </>
                             ) : (
-                              <Button type={'weak'} onClick={() => handlers.editCurrentNode()}>
+                              <Button
+                                disabled={!data.editable}
+                                type={'weak'}
+                                onClick={() => handlers.editCurrentNode()}
+                              >
                                 编辑
                               </Button>
                             )}

--- a/web/src/polaris/configuration/fileGroup/detail/file/PageDuck.tsx
+++ b/web/src/polaris/configuration/fileGroup/detail/file/PageDuck.tsx
@@ -154,7 +154,7 @@ export default class PageDuck extends Base {
     const { types } = this
     return {
       ...super.reducers,
-      data: reduceFromPayload(types.SET_COMPOSE_ID, {} as ConfigFileGroup),
+      data: reduceFromPayload(types.SET_DATA, {} as ConfigFileGroup),
       composedId: reduceFromPayload(types.SET_COMPOSE_ID, {} as ComposedId),
       fileTree: reduceFromPayload(types.SET_FILE_TREE, {}),
       expandedIds: reduceFromPayload(types.SET_EXPANDED_IDS, [] as string[]),


### PR DESCRIPTION
### snapshot

![image](https://user-images.githubusercontent.com/22773923/204203237-10fbb0bc-4630-4935-920d-18fc2605a20f.png)
