### PR TITLE
fix: 服务列表没有选健康状态过滤条件,请求依然带上了默认健康状态条件

### DIFF
--- a/web/src/polaris/service/detail/instance/PageDuck.ts
+++ b/web/src/polaris/service/detail/instance/PageDuck.ts
@@ -227,6 +227,12 @@ export default class ServicePageDuck extends GridPageDuck {
           else customFilters[key] = tag.values[0].key
         }
       })
+      // https://github.com/polarismesh/polaris/issues/793
+      // 因为上面设置默认“健康状态”为“健康”，如果没有选择“健康状态”，就默认“健康状态”为“全部”
+      const hasHealthyTag = validTags.find(tag => HealthyTagKey === tag?.attr?.key)
+      if (!hasHealthyTag) {
+        customFilters[HealthyTagKey] = '__all__'
+      }
       yield put({ type: types.SET_CUSTOM_FILTERS, payload: customFilters })
     })
     yield takeLatest(ducks.grid.types.FETCH_DONE, function*(action) {


### PR DESCRIPTION
### Issue

https://github.com/polarismesh/polaris/issues/793

### Screenshot

![image](https://user-images.githubusercontent.com/22773923/207372249-78e0cfc3-d30d-4ac5-bdd6-780cca0880c5.png)

