### PR TITLE
feat:调整服务请求数图为速率指标

### DIFF
--- a/web/src/polaris/monitor/registryMonitor/types.ts
+++ b/web/src/polaris/monitor/registryMonitor/types.ts
@@ -115,12 +115,12 @@ export const getQueryMap = {
         name: '均值',
         query:
           interfaceName && podName
-            ? `avg(client_rq_timeout{api=~"${interfaceName}",polaris_server_instance="${podName}"}) or on() vector(0)`
+            ? `avg(client_rq_timeout_avg{api=~"${interfaceName}",polaris_server_instance="${podName}"}) or on() vector(0)`
             : interfaceName
-            ? `avg(client_rq_timeout{api=~"${interfaceName}"}) or on() vector(0)`
+            ? `avg(client_rq_timeout_avg{api=~"${interfaceName}"}) or on() vector(0)`
             : podName
-            ? `avg(client_rq_timeout{polaris_server_instance="${podName}"}) or on() vector(0)`
-            : `avg(client_rq_timeout) or on() vector(0)`,
+            ? `avg(client_rq_timeout_avg{polaris_server_instance="${podName}"}) or on() vector(0)`
+            : `avg(client_rq_timeout_avg) or on() vector(0)`,
         boardFunction: AvgReduceFunction,
         unit: 'ms',
         minStep: 60,
@@ -130,12 +130,12 @@ export const getQueryMap = {
         name: '最大值',
         query:
           interfaceName && podName
-            ? `max(client_rq_timeout{api=~"${interfaceName}",polaris_server_instance="${podName}"}) or on() vector(0)`
+            ? `max(client_rq_timeout_avg{api=~"${interfaceName}",polaris_server_instance="${podName}"}) or on() vector(0)`
             : interfaceName
-            ? `max(client_rq_timeout{api=~"${interfaceName}"}) or on() vector(0)`
+            ? `max(client_rq_timeout_avg{api=~"${interfaceName}"}) or on() vector(0)`
             : podName
-            ? `max(client_rq_timeout{polaris_server_instance="${podName}"}) or on() vector(0)`
-            : `max(client_rq_timeout) or on() vector(0)`,
+            ? `max(client_rq_timeout_avg{polaris_server_instance="${podName}"}) or on() vector(0)`
+            : `max(client_rq_timeout_avg) or on() vector(0)`,
         boardFunction: MaxReduceFunction,
         unit: 'ms',
         minStep: 60,
@@ -145,12 +145,12 @@ export const getQueryMap = {
         name: '最小值',
         query:
           interfaceName && podName
-            ? `min(client_rq_timeout{api=~"${interfaceName}",polaris_server_instance="${podName}"}) or on() vector(0)`
+            ? `min(client_rq_timeout_avg{api=~"${interfaceName}",polaris_server_instance="${podName}"}) or on() vector(0)`
             : interfaceName
-            ? `min(client_rq_timeout{api=~"${interfaceName}"}) or on() vector(0)`
+            ? `min(client_rq_timeout_avg{api=~"${interfaceName}"}) or on() vector(0)`
             : podName
-            ? `min(client_rq_timeout{polaris_server_instance="${podName}"}) or on() vector(0)`
-            : `min(client_rq_timeout) or on() vector(0)`,
+            ? `min(client_rq_timeout_avg{polaris_server_instance="${podName}"}) or on() vector(0)`
+            : `min(client_rq_timeout_avg) or on() vector(0)`,
         boardFunction: MinReduceFunction,
         unit: 'ms',
         minStep: 60,
@@ -160,12 +160,12 @@ export const getQueryMap = {
         name: 'P99',
         query:
           interfaceName && podName
-            ? `quantile(0.99, client_rq_timeout{api=~"${interfaceName}",polaris_server_instance="${podName}"}) or on() vector(0)`
+            ? `quantile(0.99, client_rq_timeout_avg{api=~"${interfaceName}",polaris_server_instance="${podName}"}) or on() vector(0)`
             : interfaceName
-            ? `quantile(0.99, client_rq_timeout{api=~"${interfaceName}"}) or on() vector(0)`
+            ? `quantile(0.99, client_rq_timeout_avg{api=~"${interfaceName}"}) or on() vector(0)`
             : podName
-            ? `quantile(0.99, client_rq_timeout{polaris_server_instance="${podName}"}) or on() vector(0)`
-            : `quantile(0.99, client_rq_timeout) or on() vector(0)`,
+            ? `quantile(0.99, client_rq_timeout_avg{polaris_server_instance="${podName}"}) or on() vector(0)`
+            : `quantile(0.99, client_rq_timeout_avg) or on() vector(0)`,
         asyncBoardFunction: async () => {
           const res = await getMonitorData({
             start,
@@ -173,12 +173,12 @@ export const getQueryMap = {
             step: interval,
             query:
               interfaceName && podName
-                ? `quantile(0.99, client_rq_timeout{api=~"${interfaceName}",polaris_server_instance="${podName}"}) or on() vector(0)`
+                ? `quantile(0.99, client_rq_timeout_avg{api=~"${interfaceName}",polaris_server_instance="${podName}"}) or on() vector(0)`
                 : interfaceName
-                ? `quantile(0.99, client_rq_timeout{api=~"${interfaceName}"}) or on() vector(0)`
+                ? `quantile(0.99, client_rq_timeout_avg{api=~"${interfaceName}"}) or on() vector(0)`
                 : podName
-                ? `quantile(0.99, client_rq_timeout{polaris_server_instance="${podName}"}) or on() vector(0)`
-                : `quantile(0.99, client_rq_timeout) or on() vector(0)`,
+                ? `quantile(0.99, client_rq_timeout_avg{polaris_server_instance="${podName}"}) or on() vector(0)`
+                : `quantile(0.99, client_rq_timeout_avg) or on() vector(0)`,
           })
           const point = res?.[0]?.values?.[0]
           if (!point) return '-'
@@ -193,12 +193,12 @@ export const getQueryMap = {
         name: 'P95',
         query:
           interfaceName && podName
-            ? `quantile(0.95, client_rq_timeout{api=~"${interfaceName}",polaris_server_instance="${podName}"}) or on() vector(0)`
+            ? `quantile(0.95, client_rq_timeout_avg{api=~"${interfaceName}",polaris_server_instance="${podName}"}) or on() vector(0)`
             : interfaceName
-            ? `quantile(0.95, client_rq_timeout{api=~"${interfaceName}"}) or on() vector(0)`
+            ? `quantile(0.95, client_rq_timeout_avg{api=~"${interfaceName}"}) or on() vector(0)`
             : podName
-            ? `quantile(0.95, client_rq_timeout{polaris_server_instance="${podName}"}) or on() vector(0)`
-            : `quantile(0.95, client_rq_timeout) or on() vector(0)`,
+            ? `quantile(0.95, client_rq_timeout_avg{polaris_server_instance="${podName}"}) or on() vector(0)`
+            : `quantile(0.95, client_rq_timeout_avg) or on() vector(0)`,
         asyncBoardFunction: async () => {
           const res = await getMonitorData({
             start,
@@ -206,12 +206,12 @@ export const getQueryMap = {
             step: interval,
             query:
               interfaceName && podName
-                ? `quantile(0.95, client_rq_timeout{api=~"${interfaceName}",polaris_server_instance="${podName}"}) or on() vector(0)`
+                ? `quantile(0.95, client_rq_timeout_avg{api=~"${interfaceName}",polaris_server_instance="${podName}"}) or on() vector(0)`
                 : interfaceName
-                ? `quantile(0.95, client_rq_timeout{api=~"${interfaceName}"}) or on() vector(0)`
+                ? `quantile(0.95, client_rq_timeout_avg{api=~"${interfaceName}"}) or on() vector(0)`
                 : podName
-                ? `quantile(0.95, client_rq_timeout{polaris_server_instance="${podName}"}) or on() vector(0)`
-                : `quantile(0.95, client_rq_timeout) or on() vector(0)`,
+                ? `quantile(0.95, client_rq_timeout_avg{polaris_server_instance="${podName}"}) or on() vector(0)`
+                : `quantile(0.95, client_rq_timeout_avg) or on() vector(0)`,
           })
           const point = res?.[0]?.values?.[0]
           if (!point) return '-'

--- a/web/src/polaris/monitor/serviceMonitor/overview/Page.tsx
+++ b/web/src/polaris/monitor/serviceMonitor/overview/Page.tsx
@@ -12,6 +12,22 @@ import { FilterType } from '../Page'
 interface Props extends DuckCmpProps<BaseInfoDuck> {
   filterMap: Record<string, React.ReactNode>
 }
+
+function getButtonValue(step: React.ReactNode): string {
+    if (typeof step === 'string') {
+        return step;
+    } else if (React.isValidElement(step)) {
+        const selectElement = step as React.ReactElement;
+        if (React.isValidElement(selectElement.props.children)) {
+            const buttonElement = selectElement.props.children as React.ReactElement;
+            if (typeof buttonElement.props.value === 'string') {
+                return buttonElement.props.value;
+            }
+        }
+    }
+    return '';
+}
+
 export default function Overview(props: Props) {
   const { duck, store, filterMap, dispatch } = props
   const { selector, creators } = duck
@@ -43,7 +59,7 @@ export default function Overview(props: Props) {
         <Col span={12}>
           <MetricCard
             {...basicQueryParam}
-            query={getQueryMap[MetricName.Request]({ calleeNamespace: namespace })}
+            query={getQueryMap[MetricName.Request]({ calleeNamespace: namespace, step: getButtonValue(filterMap[FilterType.Step]) })}
             cardProps={{ bordered: true }}
             cardBodyProps={{ title: '服务请求数' }}
           ></MetricCard>

--- a/web/src/polaris/monitor/serviceMonitor/service/Page.tsx
+++ b/web/src/polaris/monitor/serviceMonitor/service/Page.tsx
@@ -325,6 +325,7 @@ export default function Overview(props: Props) {
                   calleeService: service,
                   calleeMethod: interfaceName,
                   calleeInstance: currentInstance?.ip,
+                  step: step,
                 })}
                 cardProps={{ bordered: true }}
                 cardBodyProps={{ title: '服务请求数' }}


### PR DESCRIPTION
之前统计的是总量，会一直增加，数据会越变越大，但是业务可能更关心的是实例请求变化的频率，总量在不断的请求下会越来越大没有意义，数字展示也不正常
![image](https://github.com/polarismesh/polaris-console/assets/66229105/d38f117a-684c-4278-8cc1-3c73d8af675f)
