### PR TITLE
feat: 前端增加自适应限流的选项

### DIFF
--- a/web/src/polaris/administration/accessLimiting/detail/Page.tsx
+++ b/web/src/polaris/administration/accessLimiting/detail/Page.tsx
@@ -5,7 +5,16 @@ import DetailPage from '@src/polaris/common/duckComponents/DetailPage'
 import { Values } from '../operations/CreateDuck'
 
 import { Form, Card, Text, Table, H6, FormItem, FormText } from 'tea-component'
-import { LimitType, LimitTypeMap, LimitMethodTypeMap, LimitAction, LimitActionMap, LimitFailoverMap } from '../types'
+import {
+  LimitResource,
+  LimitResourceMap,
+  LimitType,
+  LimitTypeMap,
+  LimitMethodTypeMap,
+  LimitAction,
+  LimitActionMap,
+  LimitFailoverMap, MaxAmountUnit, MaxAmountHeader,
+} from '../types'
 import insertCSS from '@src/polaris/common/helpers/insertCSS'
 
 insertCSS(
@@ -38,6 +47,7 @@ export default purify(function AccessLimitingDetailPag(props: DuckCmpProps<Acces
   const { ruleDetail } = selector(store)
   const {
     name,
+    resource: strResource,
     type: strLimitType,
     namespace,
     service,
@@ -69,6 +79,11 @@ export default purify(function AccessLimitingDetailPag(props: DuckCmpProps<Acces
             <FormItem label='限流规则名称'>
               <FormText>{name || '-'}</FormText>
             </FormItem>
+
+            <FormItem label='限流资源'>
+              <FormText>{LimitResourceMap[strResource]}</FormText>
+            </FormItem>
+
             <FormItem label='限流类型'>
               <FormText>{LimitTypeMap[strLimitType]}</FormText>
             </FormItem>
@@ -183,12 +198,20 @@ export default purify(function AccessLimitingDetailPag(props: DuckCmpProps<Acces
                                 )
                               },
                             },
+                            strResource === LimitResource.CPU && {
+                              key: 'precision',
+                              header: '滑动窗口精度',
+                              render: item => {
+                                const { precision } = item
+                                return <Text>{precision}</Text>
+                              },
+                            },
                             {
                               key: 'maxAmount',
-                              header: '请求数阈值',
+                              header: MaxAmountHeader[strResource],
                               render: item => {
                                 const { maxAmount } = item
-                                return <Text>{maxAmount}次</Text>
+                                return <Text>{maxAmount}{MaxAmountUnit[strResource]}</Text>
                               },
                             },
                           ]}

--- a/web/src/polaris/administration/accessLimiting/detail/Page.tsx
+++ b/web/src/polaris/administration/accessLimiting/detail/Page.tsx
@@ -211,7 +211,12 @@ export default purify(function AccessLimitingDetailPag(props: DuckCmpProps<Acces
                               header: MaxAmountHeader[strResource],
                               render: item => {
                                 const { maxAmount } = item
-                                return <Text>{maxAmount}{MaxAmountUnit[strResource]}</Text>
+                                return (
+                                  <Text>
+                                    {maxAmount}
+                                    {MaxAmountUnit[strResource]}
+                                  </Text>
+                                )
                               },
                             },
                           ]}

--- a/web/src/polaris/administration/accessLimiting/detail/PageDuck.ts
+++ b/web/src/polaris/administration/accessLimiting/detail/PageDuck.ts
@@ -112,7 +112,7 @@ export default class AccessLimitingDetailPageDuck extends DetailPage {
           result.totalCount > 0 &&
           result.list.map((item: RateLimit) => ({
             ...item,
-            disable: item.disable,
+            disable: item.disable === false ? true : false,
             amounts:
               item.amounts?.length > 0
                 ? item.amounts.map(o => ({

--- a/web/src/polaris/administration/accessLimiting/detail/PageDuck.ts
+++ b/web/src/polaris/administration/accessLimiting/detail/PageDuck.ts
@@ -112,7 +112,7 @@ export default class AccessLimitingDetailPageDuck extends DetailPage {
           result.totalCount > 0 &&
           result.list.map((item: RateLimit) => ({
             ...item,
-            disable: item.disable === false ? true : false,
+            disable: item.disable,
             amounts:
               item.amounts?.length > 0
                 ? item.amounts.map(o => ({
@@ -120,6 +120,7 @@ export default class AccessLimitingDetailPageDuck extends DetailPage {
                     maxAmount: o.maxAmount,
                     validDurationNum: Number(o.validDuration.substring(0, o.validDuration.length - 1)),
                     validDurationUnit: o.validDuration.substring(o.validDuration.length - 1, o.validDuration.length),
+                    precision: o.precision,
                   }))
                 : [],
             arguments:

--- a/web/src/polaris/administration/accessLimiting/model.ts
+++ b/web/src/polaris/administration/accessLimiting/model.ts
@@ -6,7 +6,7 @@ import {
   LimitMethodType,
   LimitArgumentsType,
   LimitFailover,
-  LimitAmountsValidationUnit,
+  LimitAmountsValidationUnit, LimitResource,
 } from './types'
 
 export interface DescribeLimitRulesParams {
@@ -26,6 +26,7 @@ export interface DescribeLimitRulesParams {
 export interface LimitConfig {
   validDuration: string
   maxAmount: number
+  precision: number
 }
 
 export interface LimitConfigForFormFilling {
@@ -34,6 +35,7 @@ export interface LimitConfigForFormFilling {
   maxAmount: number
   validDurationNum: number
   validDurationUnit: LimitAmountsValidationUnit
+  precision: number // 滑动窗口精度
 }
 
 interface LimitMethodConfig {
@@ -101,6 +103,7 @@ export async function describeLimitRules(params: DescribeLimitRulesParams) {
 export interface CreateLimitRulesBaseParams {
   id?: string
   name: string // 规则名
+  resource: LimitResource // 限流资源
   type: LimitType // 限流类型
   namespace: string // 规则所属命名空间
   service: string // 规则所属服务名
@@ -110,7 +113,6 @@ export interface CreateLimitRulesBaseParams {
   max_queue_delay: number // 匀速排队的最大排队时长
   failover: LimitFailover // 失败处理策略
   disable: boolean // 是否停用该限流规则，默认启用
-  resource: string
 }
 
 export interface CreateLimitRulesParams extends CreateLimitRulesBaseParams {

--- a/web/src/polaris/administration/accessLimiting/operations/Create.tsx
+++ b/web/src/polaris/administration/accessLimiting/operations/Create.tsx
@@ -35,7 +35,7 @@ import {
   LimitFailoverOptions,
   LimitFailover,
   LimitAmountsValidationUnit,
-  LimitAmountsValidationUnitOptions, MaxAmountUnit, MaxAmountHeader,
+  LimitAmountsValidationUnitOptions, MaxAmountUnit, MaxAmountHeader, MaxAmountDefault,
 } from '../types'
 import insertCSS from '@src/polaris/common/helpers/insertCSS'
 import { FieldAPI } from '@src/polaris/common/ducks/Form'
@@ -599,10 +599,10 @@ export default purify(function LimitRuleCreatePage(props: DuckCmpProps<LimitRule
                           onClick={() =>
                             amountsField.asArray().push({
                               id: `${Math.round(Math.random() * 10000)}`,
-                              maxAmount: 1,
+                              maxAmount: MaxAmountDefault[limitResource],
                               validDurationNum: 1,
                               validDurationUnit: LimitAmountsValidationUnit.s,
-                              precision: 1,
+                              precision: 10,
                             })
                           }
                         >

--- a/web/src/polaris/administration/accessLimiting/operations/CreateDuck.ts
+++ b/web/src/polaris/administration/accessLimiting/operations/CreateDuck.ts
@@ -221,6 +221,7 @@ export default class LimitRuleCreatePageDuck extends DetailPage {
       const handledAmounts = values.amounts.map(item => ({
         maxAmount: item.maxAmount,
         validDuration: `${item.validDurationNum}${item.validDurationUnit}`,
+        precision: item.precision,
       }))
 
       const handledArguments = values.arguments.map(item => ({
@@ -278,6 +279,7 @@ export default class LimitRuleCreatePageDuck extends DetailPage {
                     maxAmount: o.maxAmount,
                     validDurationNum: Number(o.validDuration.substring(0, o.validDuration.length - 1)),
                     validDurationUnit: o.validDuration.substring(o.validDuration.length - 1, o.validDuration.length),
+                    precision: o.precision,
                   }))
                 : [],
             arguments:

--- a/web/src/polaris/administration/accessLimiting/types.ts
+++ b/web/src/polaris/administration/accessLimiting/types.ts
@@ -5,6 +5,41 @@ export interface Lists {
   serviceList: []
 }
 
+// 限制资源类型，支持QPS, CPU
+export enum LimitResource {
+  QPS = 'QPS',
+  // CONCURRENCY = 'CONCURRENCY', // 并发量
+  CPU = 'CPU',
+}
+export const LimitResourceOptions = [
+  {
+    value: LimitResource.QPS,
+    text: 'QPS',
+  },
+  {
+    value: LimitResource.CPU,
+    text: 'CPU使用率',
+  },
+]
+export const LimitResourceMap = LimitResourceOptions.reduce((map, curr) => {
+  map[curr.value] = curr.text
+  return map
+}, {})
+
+// 阈值的标题
+export enum MaxAmountHeader {
+  QPS = '请求数阈值',
+  // CONCURRENCY = '次',
+  CPU = 'CPU使用率阈值',
+}
+
+// 阈值的计数单位
+export enum MaxAmountUnit {
+  QPS = '次',
+  // CONCURRENCY = '次',
+  CPU = '%',
+}
+
 // 限流类型，支持LOCAL（单机限流）, GLOBAL（分布式限流）
 export enum LimitType {
   GLOBAL = 'GLOBAL',
@@ -26,10 +61,11 @@ export const LimitTypeMap = LimitTypeOptions.reduce((map, curr) => {
   return map
 }, {})
 
-// 限流效果，支持REJECT（直接拒绝）,UNIRATE（匀速排队），默认REJECT
+// 限流效果，支持REJECT（直接拒绝）,UNIRATE（匀速排队），BBR（自适应），默认REJECT
 export enum LimitAction {
-  REJECT = 'REJECT',
-  UNIRATE = 'UNIRATE',
+  REJECT = 'REJECT', // 实现为令牌桶
+  UNIRATE = 'UNIRATE', // 实现为漏桶
+  BBR = 'BBR',
 }
 export const LimitActionOptions = [
   {
@@ -39,6 +75,10 @@ export const LimitActionOptions = [
   {
     value: LimitAction.UNIRATE,
     text: '匀速排队',
+  },
+  {
+    value: LimitAction.BBR,
+    text: '自适应',
   },
 ]
 
@@ -213,6 +253,7 @@ export const generateDefaultValues: Values = {
       validDurationNum: 1,
       validDurationUnit: LimitAmountsValidationUnit.s,
       maxAmount: 1,
+      precision: 1,
     },
   ],
   regex_combine: true,
@@ -220,5 +261,5 @@ export const generateDefaultValues: Values = {
   max_queue_delay: 1,
   failover: LimitFailover.FAILOVER_LOCAL,
   disable: true,
-  resource: 'QPS',
+  resource: LimitResource.QPS,
 }

--- a/web/src/polaris/administration/accessLimiting/types.ts
+++ b/web/src/polaris/administration/accessLimiting/types.ts
@@ -40,6 +40,13 @@ export enum MaxAmountUnit {
   CPU = '%',
 }
 
+// 阈值的计数单位
+export enum MaxAmountDefault {
+  QPS = 1,
+  // CONCURRENCY = '次',
+  CPU = 80,
+}
+
 // 限流类型，支持LOCAL（单机限流）, GLOBAL（分布式限流）
 export enum LimitType {
   GLOBAL = 'GLOBAL',
@@ -253,7 +260,7 @@ export const generateDefaultValues: Values = {
       validDurationNum: 1,
       validDurationUnit: LimitAmountsValidationUnit.s,
       maxAmount: 1,
-      precision: 1,
+      precision: 10,
     },
   ],
   regex_combine: true,


### PR DESCRIPTION

1. 限流资源新增【CPU使用率】类型
2. 选择CPU使用率类型时:
    - 限制只能单机限流
    - 阈值变为【CPU使用率阈值】，单位变为%；增加【滑动窗口精度】配置选项
    - 限流方案变为【自适应】
 

<img width="932" alt="image" src="https://github.com/polarismesh/polaris-console/assets/9314475/de2b78e2-2ec8-4ae6-af17-546ae80a1fa6">
