### PR TITLE
fix: 修改判断健康检查是否开启时使用的字段

### DIFF
--- a/web/src/polaris/service/detail/instance/Page.tsx
+++ b/web/src/polaris/service/detail/instance/Page.tsx
@@ -370,9 +370,9 @@ export default function ServiceInstancePage(props: DuckCmpProps<ServicePageDuck>
                         </FormText>
                       </FormItem>
                       <FormItem label='健康检查'>
-                        <FormText>{record.healthCheck?.type ? '开启' : '关闭'}</FormText>
+                        <FormText>{record.enableHealthCheck ? '开启' : '关闭'}</FormText>
                       </FormItem>
-                      {record.healthCheck?.type && (
+                      {record.enableHealthCheck && (
                         <FormItem label='健康检查方式'>
                           <FormText>
                             检查方式：


### PR DESCRIPTION
polaris-go 通过 `RegisterInstance` 方法进行服务注册后，若通过 `Register` 方法再次进行注册，可能会导致健康检查关闭，但健康检查规则仍然存在。
前端详情页判断健康健康开关时，使用的是判断健康检查规则是否存在的逻辑，该情况下在详情页显示错误。

<img width="1389" alt="image" src="https://github.com/polarismesh/polaris-console/assets/9314475/2f79d5a9-dbe7-48b7-b98f-3d8e40d37169">